### PR TITLE
src: corrected package naming to library package convention

### DIFF
--- a/src/.ci/_package-npm_unix-any.sh
+++ b/src/.ci/_package-npm_unix-any.sh
@@ -40,7 +40,7 @@ PACKAGE_Assemble_NPM_Content() {
 
 
         # execute
-        __dest="${_directory}/${PROJECT_SKU}_${PROJECT_VERSION}_js-js.tgz"
+        __dest="${_directory}/lib${PROJECT_SKU}-npm_${PROJECT_VERSION}_js-js.tgz"
         I18N_Copy "$_target" "$__dest"
         FS_Copy_File "$_target" "$__dest"
         if [ $? -ne 0 ]; then

--- a/src/.ci/_package-npm_windows-any.ps1
+++ b/src/.ci/_package-npm_windows-any.ps1
@@ -41,7 +41,7 @@ function PACKAGE-Assemble-NPM-Content {
 
 
 	# execute
-	$__dest = "${_directory}\${env:PROJECT_SKU}_${env:PROJECT_VERSION}_js-js.tgz"
+	$__dest = "${_directory}\lib${env:PROJECT_SKU}-npm_${env:PROJECT_VERSION}_js-js.tgz"
 	$null = I18N-Copy "${_target}" "${__dest}"
 	$___process = FS-Copy-File "${_target}" "${__dest}"
 	if ($___process -ne 0) {


### PR DESCRIPTION
Since npm is a library package, it's best we correct it to the library package naming convention for consistency purposes. Hence, let's do this.

This patch corrects npm packing naming creation with library package convention in src/ directory.