### PR TITLE
automataCI: enabled release branches automation strategy

### DIFF
--- a/CONFIG.toml
+++ b/CONFIG.toml
@@ -150,6 +150,25 @@ PROJECT_CONTACT_WEBSITE = "https://github.com/ChewKeanHo/hestiaERROR"
 PROJECT_SOURCE_URL = "https://github.com/ChewKeanHo/hestiaERROR"
 
 
+# PROJECT_SOURCE_GIT_REMOTE
+# The git remote tag for the project release publications. This is used for
+# sourcing the upstream git configurations. Unless absolute required, this field
+# can be left intact.
+#
+# Default is: 'origin'
+PROJECT_SOURCE_GIT_REMOTE = 'origin'
+
+
+# PROJECT_SOURCE_RELEASE_TAG_LATEST
+# The tag label for latest release and also a flag to trigger release branches
+# strategies.
+#
+# Default is: 'latest'
+# To enable release branch strategy: fill in the label
+# To disable: leave it empty ('')
+PROJECT_SOURCE_RELEASE_TAG_LATEST = 'latest'
+
+
 # AUTOMATACI_LANG
 # Overrides AutomataCI to operate in 1 specific language. Otherwise, AutomataCI
 # shall query the system language settings. Only accepts language code complying
@@ -534,6 +553,16 @@ PROJECT_NODE_VERSION = 'v22.2.0'
 #
 # Default is: 'https://npm.pkg.github.com'
 PROJECT_NODE_NPM_REGISTRY = 'https://npm.pkg.github.com'
+
+
+# PROJECT_NODE_BRANCH_TAG
+# This is for technology tagging purposes such as but not limited to release
+# branches identification. The value shall always be lowercase, short, and
+# directly identify it is Node technology.
+#
+# Default is: 'npm'
+# To disable: set it empty ''
+PROJECT_NODE_BRANCH_TAG = 'npm'
 
 
 

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # Hestia Libraries - `hestiaERROR`
 
-[![Hestia Libraries](/src/icons/banner_1200x270.svg)](#)
+[![Hestia Libraries](https://raw.githubusercontent.com/ChewKeanHo/hestiaERROR/main/src/icons/banner_1200x270.svg)](#)
 
 One Peaceful Frontend+Backend Software Library Suite.
 
@@ -75,7 +75,7 @@ involving `npm`:
 {
   "dependencies": {
     ...
-    "@chewkeanho/hestiaERROR": "git+https://github.com/ChewKeanHo/hestiaERROR.git#[VERSION]_js"
+    "@chewkeanho/hestiaERROR": "git+https://github.com/ChewKeanHo/hestiaERROR.git#[VERSION]_npm"
     ...
   }
 }
@@ -88,7 +88,7 @@ For always latest release, please use the `latest` version tag. Example:
   ...
   "dependencies": {
     ...
-    "@chewkeanho/hestiaERROR": "git+https://github.com/ChewKeanHo/hestiaERROR.git#latest_js"
+    "@chewkeanho/hestiaERROR": "git+https://github.com/ChewKeanHo/hestiaERROR.git#latest_npm"
     ...
   }
   ...

--- a/automataCI/_release-lib_unix-any.sh
+++ b/automataCI/_release-lib_unix-any.sh
@@ -1,0 +1,131 @@
+#!/bin/sh
+# Copyright 2024 (Holloway) Chew, Kean Ho <hello@hollowaykeanho.com>
+#
+# Licensed under the Apache License, Version 2.0 (the "License"); you may not
+# use this file except in compliance with the License. You may obtain a copy of
+# the License at:
+#                 http://www.apache.org/licenses/LICENSE-2.0
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+# WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+# License for the specific language governing permissions and limitations under
+# the License.
+. "${LIBS_AUTOMATACI}/services/io/fs.sh"
+. "${LIBS_AUTOMATACI}/services/io/os.sh"
+. "${LIBS_AUTOMATACI}/services/io/strings.sh"
+. "${LIBS_AUTOMATACI}/services/archive/tar.sh"
+. "${LIBS_AUTOMATACI}/services/archive/zip.sh"
+. "${LIBS_AUTOMATACI}/services/i18n/translations.sh"
+. "${LIBS_AUTOMATACI}/services/versioners/git.sh"
+
+
+
+
+# initialize
+if [ "$PROJECT_PATH_ROOT" = "" ]; then
+        >&2 printf "[ ERROR ] - Please run me from automataCI/ci.sh.ps1 instead!\n"
+        return 1
+fi
+
+
+
+
+RELEASE_Run_LIBS() {
+        #_target="$1"
+
+
+        # validate input
+        if [ $(STRINGS_Is_Empty "$PROJECT_SOURCE_RELEASE_TAG_LATEST") -eq 0 ]; then
+                return 0
+        fi
+
+        if [ $(FS_Is_Target_A_Library "$1") -ne 0 ]; then
+                return 0
+        fi
+
+        if [ $(STRINGS_Is_Empty "$PROJECT_SOURCE_GIT_REMOTE") -eq 0 ]; then
+                return 0
+        fi
+
+        GIT_Is_Available
+        if [ $? -ne 0 ]; then
+                return 0
+        fi
+
+
+        # execute
+        ## identify tag
+        __branch="v${PROJECT_VERSION}"
+        if [ $(FS_Is_Target_A_NPM "$1") -eq 0 ]; then
+                if [ $(STRINGS_Is_Empty "$PROJECT_NODE_BRANCH_TAG") -eq 0 ]; then
+                        return 0
+                fi
+
+                __branch="${__branch}_${PROJECT_NODE_BRANCH_TAG}"
+        else
+                return 0
+        fi
+
+        I18N_Publish "git@$__branch"
+        if [ $(OS_Is_Run_Simulated) -eq 0 ]; then
+                I18N_Simulate_Publish "$__branch"
+                return 0
+        fi
+
+        ## create workspace directory
+        __workspace="${PROJECT_PATH_ROOT}/${PROJECT_PATH_TEMP}/release-branch_${__branch}"
+        GIT_Setup_Workspace_Bare "$PROJECT_SOURCE_GIT_REMOTE" "$__branch" "$__workspace"
+        if [ $? -ne 0 ]; then
+                I18N_Publish_Failed
+                return 1
+        fi
+
+        ## unpack package into directory
+        if [ $(FS_Is_Target_A_TARGZ "$1") -eq 0 ]; then
+                TAR_Extract_GZ "$__workspace" "$1"
+        elif [ $(FS_Is_Target_A_TARXZ "$1") -eq 0 ]; then
+                TAR_Extract_XZ "$__workspace" "$1"
+        elif [ $(FS_Is_Target_A_ZIP "$1") -eq 0 ]; then
+                ZIP_Extract "$__workspace" "$1"
+        else
+                FS_Copy_File "$1" "${__workspace}"
+        fi
+
+        if [ $? -ne 0 ]; then
+                I18N_Publish_Failed
+                return 1
+        fi
+
+        ## commit release
+        __current_path="$PWD" && cd "$__workspace"
+        GIT_Autonomous_Commit "$__branch"
+        ___process=$?
+        cd "$__current_path" && unset __current_path
+        if [ $___process -ne 0 ]; then
+                I18N_Publish_Failed
+                return 1
+        fi
+
+        ## push to upstream
+        GIT_Push_Specific "$__workspace" \
+                "$PROJECT_SOURCE_GIT_REMOTE" \
+                "$__branch" \
+                "$__branch"
+        if [ $? -ne 0 ]; then
+                I18N_Publish_Failed
+                return 1
+        fi
+
+        GIT_Push_Specific "$__workspace" \
+                "$PROJECT_SOURCE_GIT_REMOTE" \
+                "$__branch" \
+                "${PROJECT_SOURCE_RELEASE_TAG_LATEST}_${__branch#*_}"
+        if [ $? -ne 0 ]; then
+                I18N_Publish_Failed
+                return 1
+        fi
+
+
+        # report status
+        return 0
+}

--- a/automataCI/_release-lib_windows-any.ps1
+++ b/automataCI/_release-lib_windows-any.ps1
@@ -1,0 +1,137 @@
+# Copyright 2024 (Holloway) Chew, Kean Ho <hello@hollowaykeanho.com>
+#
+# Licensed under the Apache License, Version 2.0 (the "License"); you may not
+# use this file except in compliance with the License. You may obtain a copy
+# of the License at:
+#               http://www.apache.org/licenses/LICENSE-2.0
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+# WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+# License for the specific language governing permissions and limitations
+# under the License.
+. "${env:LIBS_AUTOMATACI}\services\io\fs.ps1"
+. "${env:LIBS_AUTOMATACI}\services\io\os.ps1"
+. "${env:LIBS_AUTOMATACI}\services\io\strings.ps1"
+. "${env:LIBS_AUTOMATACI}\services\archive\tar.ps1"
+. "${env:LIBS_AUTOMATACI}\services\archive\zip.ps1"
+. "${env:LIBS_AUTOMATACI}\services\i18n\translations.ps1"
+. "${env:LIBS_AUTOMATACI}\services\versioners\git.ps1"
+
+
+
+
+# initialize
+if (-not (Test-Path -Path $env:PROJECT_PATH_ROOT)) {
+	Write-Error "[ ERROR ] - Please run from automataCI\ci.sh.ps1 instead!`n"
+	return
+}
+
+
+
+
+function RELEASE-Run-LIBS {
+	param(
+		[string]$_target
+	)
+
+
+	# validate input
+	if ($(STRINGS-Is-Empty "${env:PROJECT_SOURCE_RELEASE_TAG_LATEST}") -eq 0) {
+		return 0
+	}
+
+	$___process = FS-Is-Target-A-Library "${_target}"
+	if ($___process -ne 0) {
+		return 0
+	}
+
+	if ($(STRINGS-Is-Empty "${env:PROJECT_SOURCE_GIT_REMOTE}") -eq 0) {
+		return 0
+	}
+
+	$___process = GIT-Is-Available
+	if ($___process -ne 0) {
+		return 0
+	}
+
+
+	# execute
+	## identify tag
+	$__branch = "v${env:PROJECT_VERSION}"
+	if ($(FS-Is-Target-A-NPM "${_target}") -eq 0) {
+		if ($(STRINGS-Is-Empty "${env:PROJECT_NODE_BRANCH_TAG}") -eq 0) {
+			return 0
+		}
+
+		$__branch = "${__branch}_${env:PROJECT_NODE_BRANCH_TAG}"
+	} else {
+		return 0
+	}
+
+	$null = I18N-Publish "git@${__branch}"
+	if ($(OS-Is-Run-Simulated) -eq 0) {
+		$null = I18N-Simulate-Publish "${__branch}"
+		return 0
+	}
+
+	## create workspace directory
+	$__workspace = "${env:PROJECT_PATH_ROOT}\${env:PROJECT_PATH_TEMP}\release-branch_${_branch}"
+	$___process = GIT-Setup-Workspace-Bare `
+		"${env:PROJECT_SOURCE_GIT_REMOTE}" `
+		"${__branch}" `
+		"${__workspace}"
+	if ($___process -ne 0) {
+		$null = I18N-Publish-Failed
+		return 1
+	}
+
+	## unpack package into directory
+	if ($(FS-Is-Target-A-TARGZ "$1") -eq 0) {
+		$___process = TAR-Extract-GZ "${__workspace}" "${_target}"
+	} elseif ($(FS-Is-Target-A-TARXZ "$1") -eq 0) {
+		$___process = TAR-Extract-XZ "${__workspace}" "${_target}"
+	} elseif ($(FS-Is-Target-A-ZIP "$1") -eq 0) {
+		$___process = ZIP-Extract "${__workspace}" "${_target}"
+	} else {
+		$___process = FS-Copy-File "${_target}" "${__workspace}"
+	}
+
+	if ($___process -ne 0) {
+		$null = I18N-Publish-Failed
+		return 1
+	}
+
+	## commit release
+	$__current_path = Get-Location
+	$null = Set-Location -Path "${__workspace}"
+	$___process = GIT-Autonomous-Commit "${__branch}"
+	$null = Set-Location -Path "${__current_path}"
+	$null = Remove-Variable -Name __current_path
+	if ($___process -ne 0) {
+		$null = I18N-Publish-Failed
+		return 1
+	}
+
+	## push to upstream
+	$___process = GIT-Push-Specific "${__workspace}" `
+		"${env:PROJECT_SOURCE_GIT_REMOTE}" `
+		"${__branch}"
+		"${__branch}"
+	if ($___process -ne 0) {
+		$null = I18N-Publish-Failed
+		return 1
+	}
+
+	$___process = GIT-Push-Specific "${__workspace}" `
+		"${env:PROJECT_SOURCE_GIT_REMOTE}" `
+		"${__branch}"
+		"${env:PROJECT_SOURCE_RELEASE_TAG_LATEST}_$($__branch -replace "^.*_", '')"
+	if ($___process -ne 0) {
+		$null = I18N-Publish-Failed
+		return 1
+	}
+
+
+	# report status
+	return 0
+}

--- a/automataCI/_release-npm_unix-any.sh
+++ b/automataCI/_release-npm_unix-any.sh
@@ -49,7 +49,7 @@ RELEASE_Run_NPM() {
         I18N_Check_Login "NPM"
         NODE_NPM_Check_Login
         if [ $? -eq 0 ]; then
-                I18N_Publish "$1"
+                I18N_Publish "NPM"
                 if [ $(OS_Is_Run_Simulated) -eq 0 ]; then
                         I18N_Simulate_Publish "$1"
                 else

--- a/automataCI/_release-npm_windows-any.ps1
+++ b/automataCI/_release-npm_windows-any.ps1
@@ -50,7 +50,7 @@ function RELEASE-Run-NPM {
 	$null = I18N-Check-Login "NPM"
 	$___process = NODE-NPM-Check-Login
 	if ($___process -eq 0) {
-		$null = I18N-Publish "${_target}"
+		$null = I18N-Publish "NPM"
 		if ($(OS-Is-Run-Simulated) -ne 0) {
 			$null = I18N-Simulate-Publish "${_target}"
 		} else {

--- a/automataCI/release_unix-any.sh
+++ b/automataCI/release_unix-any.sh
@@ -32,6 +32,7 @@ fi
 . "${LIBS_AUTOMATACI}/_release-deb_unix-any.sh"
 . "${LIBS_AUTOMATACI}/_release-docker_unix-any.sh"
 . "${LIBS_AUTOMATACI}/_release-homebrew_unix-any.sh"
+. "${LIBS_AUTOMATACI}/_release-lib_unix-any.sh"
 . "${LIBS_AUTOMATACI}/_release-npm_unix-any.sh"
 . "${LIBS_AUTOMATACI}/_release-pypi_unix-any.sh"
 . "${LIBS_AUTOMATACI}/_release-rpm_unix-any.sh"
@@ -119,6 +120,11 @@ for TARGET in "${PROJECT_PATH_ROOT}/${PROJECT_PATH_PKG}"/*; do
         fi
 
         RELEASE_Run_DOCKER "$TARGET"
+        if [ $? -ne 0 ]; then
+                return 1
+        fi
+
+        RELEASE_Run_LIBS "$TARGET"
         if [ $? -ne 0 ]; then
                 return 1
         fi

--- a/automataCI/release_windows-any.ps1
+++ b/automataCI/release_windows-any.ps1
@@ -31,6 +31,7 @@ if (-not (Test-Path -Path $env:PROJECT_PATH_ROOT)) {
 . "${env:LIBS_AUTOMATACI}\_release-deb_windows-any.ps1"
 . "${env:LIBS_AUTOMATACI}\_release-docker_windows-any.ps1"
 . "${env:LIBS_AUTOMATACI}\_release-homebrew_windows-any.ps1"
+. "${env:LIBS_AUTOMATACI}\_release-lib_windows-any.ps1"
 . "${env:LIBS_AUTOMATACI}\_release-npm_windows-any.ps1"
 . "${env:LIBS_AUTOMATACI}\_release-pypi_windows-any.ps1"
 . "${env:LIBS_AUTOMATACI}\_release-rpm_windows-any.ps1"
@@ -127,6 +128,11 @@ if (Test-Path -PathType Container -Path "${PACKAGE_DIRECTORY}") {
 		}
 
 		$___process = RELEASE-Run-HOMEBREW "$TARGET" "$HOMEBREW_REPO"
+		if ($___process -ne 0) {
+			return 1
+		}
+
+		$___process = RELEASE-Run-LIBS "$TARGET"
 		if ($___process -ne 0) {
 			return 1
 		}

--- a/automataCI/services/compilers/node.sh
+++ b/automataCI/services/compilers/node.sh
@@ -199,8 +199,7 @@ NODE_NPM_Is_Valid() {
 
 
         # execute
-        FS_Is_Target_A_NPM "$1"
-        if [ $? -ne 0 ]; then
+        if [ $(FS_Is_Target_A_NPM "$1") -ne 0 ]; then
                 return 1
         fi
 

--- a/automataCI/services/io/fs.ps1
+++ b/automataCI/services/io/fs.ps1
@@ -578,6 +578,46 @@ function FS-Is-Target-A-Source {
 
 
 
+function FS-Is-Target-A-TARGZ {
+	param (
+		[string]$___target
+	)
+
+
+	# execute
+	if (($("${___target}" -replace '^.*.tar.gz') -ne "${___target}") -or
+		($("${___target}" -replace '^.*.tgz') -ne "${___target}")) {
+		return 0
+	}
+
+
+	# report status
+	return 1
+}
+
+
+
+
+function FS-Is-Target-A-TARXZ {
+	param (
+		[string]$___target
+	)
+
+
+	# execute
+	if (($("${___target}" -replace '^.*.tar.xz') -ne "${___target}") -or
+		($("${___target}" -replace '^.*.txz') -ne "${___target}")) {
+		return 0
+	}
+
+
+	# report status
+	return 1
+}
+
+
+
+
 function FS-Is-Target-A-WASM {
 	param (
 		[string]$___target
@@ -635,6 +675,25 @@ function FS-Is-Target-Exist {
 	# perform checking
 	$___process = Test-Path -Path "${___target}" -PathType Any -ErrorAction SilentlyContinue
 	if ($___process) {
+		return 0
+	}
+
+
+	# report status
+	return 1
+}
+
+
+
+
+function FS-Is-Target-A-ZIP {
+	param (
+		[string]$___target
+	)
+
+
+	# execute
+	if ($("${___target}" -replace '^.*.zip') -ne "${___target}") {
 		return 0
 	}
 

--- a/automataCI/services/io/fs.sh
+++ b/automataCI/services/io/fs.sh
@@ -534,6 +534,44 @@ FS_Is_Target_A_Source() {
 
 
 
+FS_Is_Target_A_TARGZ() {
+        #___target="$1"
+
+
+        # execute
+        if [ "${1#*.tar.gz}" != "$1" ] || [ "${1#*.tgz}" != "$1" ]; then
+                printf -- "0"
+                return 0
+        fi
+
+
+        # report status
+        printf -- "1"
+        return 1
+}
+
+
+
+
+FS_Is_Target_A_TARXZ() {
+        #___target="$1"
+
+
+        # execute
+        if [ "${1#*.tar.xz}" != "$1" ] || [ "${1#*.txz}" != "$1" ]; then
+                printf -- "0"
+                return 0
+        fi
+
+
+        # report status
+        printf -- "1"
+        return 1
+}
+
+
+
+
 FS_Is_Target_A_WASM() {
         #___target="$1"
 
@@ -572,6 +610,25 @@ FS_Is_Target_A_WASM_JS() {
         # report status
         printf -- "0"
         return 0
+}
+
+
+
+
+FS_Is_Target_A_ZIP() {
+        #___target="$1"
+
+
+        # execute
+        if [ "${1#*.zip}" != "$1" ]; then
+                printf -- "0"
+                return 0
+        fi
+
+
+        # report status
+        printf -- "1"
+        return 1
 }
 
 


### PR DESCRIPTION
Since multiple technologies like npm and go uses release branches significantly, we have to enable release branches automation strategy to facilitate such needs. Hence, let's do this.

This patch enables release branches automation strategy in automataCI/ directory.