### PR TITLE
root: enabled research paper pipeline (srcRESEARCH)

### DIFF
--- a/CONFIG.toml
+++ b/CONFIG.toml
@@ -449,6 +449,10 @@ GOOGLEAI_BLOCK_HARASSMENT = 'BLOCK_NONE'
 # notify the CI provider to setup a localized virtual environment for
 # development automatically.
 #
+# Do note that should the following technologies are enabled, LibreOffice shall
+# be installed regardless of this control variable:
+#     (1) PROJECT_RESEARCH - using Libreoffice by default.
+#
 # To enable it: simply supply the path (e.g. default is 'srcLIBREOFFICE').
 # To disable it: simply supply an empty path (e.g. default is '').
 PROJECT_LIBREOFFICE = ''
@@ -462,8 +466,7 @@ PROJECT_LIBREOFFICE = ''
 #
 # Refer to the following mirror list for value selection:
 #     (1) https://download.documentfoundation.org/mirmon/allmirrors.html
-PROJECT_LIBREOFFICE_MIRROR = "https://ftp.osuosl.org/pub/tdf/libreoffice"
-
+PROJECT_LIBREOFFICE_MIRROR = "https://download.documentfoundation.org/libreoffice"
 
 # PROJECT_LIBREOFFICE_VERSION
 # This is for defining the LibreOffice version to install into the local OS.
@@ -471,8 +474,14 @@ PROJECT_LIBREOFFICE_MIRROR = "https://ftp.osuosl.org/pub/tdf/libreoffice"
 # Refer the the following list for value selection:
 #     (1) https://www.libreoffice.org/download/download-libreoffice/
 #
-# Example: '24.2.1' for 'LibreOffice 24.2.1'
-PROJECT_LIBREOFFICE_VERSION = "24.2.1"
+# Example: '24.4.3' for 'LibreOffice 24.4.3'
+PROJECT_LIBREOFFICE_VERSION = "24.2.3"
+
+
+# PROJECT_PATH_LIBREOFFICE_ENGINE
+# This is a relative pathing to PROJECT_PATH_ROOT + PROJECT_PATH_TOOLS for
+# setting up localized environment.
+PROJECT_PATH_LIBREOFFICE_ENGINE = "libreoffice-engine"
 
 
 
@@ -646,7 +655,19 @@ PROJECT_PYPI_README_MIME = "text/markdown"
 #
 # To enable it: simply supply the path (e.g. default is 'srcRESEARCH').
 # To disable it: simply supply an empty path (e.g. default is '').
-PROJECT_RESEARCH = ''
+PROJECT_RESEARCH = 'srcRESEARCH'
+
+
+# PROJECT_RESEARCH_IDENTIFIER
+# The file identifier for the compiled output paper file from its peers with the
+# same formats (e.g. a bunch of PDFs). This is suffix-ed within the filename
+# itself like:
+#
+#    pattern: '${PROJECT_SKU}-${PROJECT_RESEARCH_IDENTIFIER}_v${PROJECT_VERSION}_any-any.pdf'
+#    example: 'automataci-RESEARCH_v100.00.100_any-any.pdf'
+#
+# default is: 'RESEARCH'
+PROJECT_RESEARCH_IDENTIFIER = 'RESEARCH'
 
 
 

--- a/automataCI/_release-pdf_unix-any.sh
+++ b/automataCI/_release-pdf_unix-any.sh
@@ -1,0 +1,54 @@
+#!/bin/sh
+# Copyright 2024 (Holloway) Chew, Kean Ho <hello@hollowaykeanho.com>
+#
+# Licensed under the Apache License, Version 2.0 (the "License"); you may not
+# use this file except in compliance with the License. You may obtain a copy of
+# the License at:
+#                 http://www.apache.org/licenses/LICENSE-2.0
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+# WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+# License for the specific language governing permissions and limitations under
+# the License.
+. "${LIBS_AUTOMATACI}/services/io/fs.sh"
+. "${LIBS_AUTOMATACI}/services/i18n/translations.sh"
+
+
+
+
+# initialize
+if [ "$PROJECT_PATH_ROOT" = "" ]; then
+        >&2 printf "[ ERROR ] - Please run me from automataCI/ci.sh.ps1 instead!\n"
+        return 1
+fi
+
+
+
+
+RELEASE_Run_PDF() {
+        #_target="$1"
+
+
+        # validate input
+        if [ $(FS_Is_Target_A_PDF "$1") -ne 0 ]; then
+                return 0
+        fi
+
+
+        # execute
+        ___dest="PAPER.pdf"
+        I18N_Publish "$___dest"
+        ___dest="${PROJECT_PATH_ROOT}/${___dest}"
+        if [ "${1##*${PROJECT_RESEARCH_IDENTIFIER}}" != "$1" ]; then
+                ## it's a research paper
+                FS_Copy_File "$1" "$___dest"
+                if [ $? -ne 0 ]; then
+                        I18N_Publish_Failed
+                        return 1
+                fi
+        fi
+
+
+        # report status
+        return 0
+}

--- a/automataCI/_release-pdf_windows-any.ps1
+++ b/automataCI/_release-pdf_windows-any.ps1
@@ -1,0 +1,56 @@
+# Copyright 2024 (Holloway) Chew, Kean Ho <hello@hollowaykeanho.com>
+#
+# Licensed under the Apache License, Version 2.0 (the "License"); you may not
+# use this file except in compliance with the License. You may obtain a copy
+# of the License at:
+#               http://www.apache.org/licenses/LICENSE-2.0
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+# WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+# License for the specific language governing permissions and limitations
+# under the License.
+. "${env:LIBS_AUTOMATACI}\services\io\fs.ps1"
+. "${env:LIBS_AUTOMATACI}\services\i18n\translations.ps1"
+
+
+
+
+# initialize
+if (-not (Test-Path -Path $env:PROJECT_PATH_ROOT)) {
+	Write-Error "[ ERROR ] - Please run from automataCI\ci.sh.ps1 instead!`n"
+	return
+}
+
+
+
+
+function RELEASE-Run-PDF {
+	param(
+		[string]$_target
+	)
+
+
+	# validate input
+	$___process = FS-Is-Target-A-PDF "${_target}"
+	if ($___process -ne 0) {
+		return 0
+	}
+
+
+	# execute
+	$___dest = "PAPER.pdf"
+	$null = I18N-Publish "${___dest}"
+	$___dest = "${env:PROJECT_PATH_ROOT}\${___dest}"
+	if ($($_target -replace "^.*${env:PROJECT_RESEARCH_IDENTIFIER}") -ne "${_target}") {
+		## it's a research paper
+		$___process = FS-Copy-File "${_target}" "${___dest}"
+		if ($___process -ne 0) {
+			$null = I18N-Publish-Failed
+			return 1
+		}
+	}
+
+
+	# report status
+	return 0
+}

--- a/automataCI/release_unix-any.sh
+++ b/automataCI/release_unix-any.sh
@@ -34,6 +34,7 @@ fi
 . "${LIBS_AUTOMATACI}/_release-homebrew_unix-any.sh"
 . "${LIBS_AUTOMATACI}/_release-lib_unix-any.sh"
 . "${LIBS_AUTOMATACI}/_release-npm_unix-any.sh"
+. "${LIBS_AUTOMATACI}/_release-pdf_unix-any.sh"
 . "${LIBS_AUTOMATACI}/_release-pypi_unix-any.sh"
 . "${LIBS_AUTOMATACI}/_release-rpm_unix-any.sh"
 . "${LIBS_AUTOMATACI}/_release-staticrepo_unix-any.sh"
@@ -135,6 +136,11 @@ for TARGET in "${PROJECT_PATH_ROOT}/${PROJECT_PATH_PKG}"/*; do
         fi
 
         RELEASE_Run_NPM "$TARGET"
+        if [ $? -ne 0 ]; then
+                return 1
+        fi
+
+        RELEASE_Run_PDF "$TARGET"
         if [ $? -ne 0 ]; then
                 return 1
         fi

--- a/automataCI/release_windows-any.ps1
+++ b/automataCI/release_windows-any.ps1
@@ -33,6 +33,7 @@ if (-not (Test-Path -Path $env:PROJECT_PATH_ROOT)) {
 . "${env:LIBS_AUTOMATACI}\_release-homebrew_windows-any.ps1"
 . "${env:LIBS_AUTOMATACI}\_release-lib_windows-any.ps1"
 . "${env:LIBS_AUTOMATACI}\_release-npm_windows-any.ps1"
+. "${env:LIBS_AUTOMATACI}\_release-pdf_windows-any.ps1"
 . "${env:LIBS_AUTOMATACI}\_release-pypi_windows-any.ps1"
 . "${env:LIBS_AUTOMATACI}\_release-rpm_windows-any.ps1"
 . "${env:LIBS_AUTOMATACI}\_release-staticrepo_windows-any.ps1"
@@ -138,6 +139,11 @@ if (Test-Path -PathType Container -Path "${PACKAGE_DIRECTORY}") {
 		}
 
 		$___process = RELEASE-Run-NPM "$TARGET"
+		if ($___process -ne 0) {
+			return 1
+		}
+
+		$___process = RELEASE-Run-PDF "$TARGET"
 		if ($___process -ne 0) {
 			return 1
 		}

--- a/automataCI/services/compilers/libreoffice.ps1
+++ b/automataCI/services/compilers/libreoffice.ps1
@@ -48,14 +48,41 @@ function LIBREOFFICE-Get {
 
 
 
+function LIBREOFFICE-Get-Path-Local {
+	$___path = "${env:PROJECT_PATH_ROOT}\${env:PROJECT_PATH_TOOLS}\${env:PROJECT_PATH_LIBREOFFICE_ENGINE}\bin\soffice"
+
+	switch ("${env:PROJECT_OS}") {
+	"windows" {
+		$___path = "${___path}.exe"
+	} default {
+		# do nothing
+	}}
+
+
+	# report status
+	return $___path
+}
+
+
+
+
 function LIBREOFFICE-Get-Path {
-	switch ("$(OS-Get)") {
+	# execute
+	$___path = LIBREOFFICE-Get-Path-Local
+	if ($(FS-Is-File "${___path}") -eq 0) {
+		return $___path
+	}
+
+	switch ("${env:PROJECT_OS}") {
 	"darwin" {
 		$___path = "/Applications/LibreOffice.app/Contents/MacOS/soffice"
 	} "windows" {
-		$___path = "C:\Program Files\LibreOffice\program\soffice.exe"
+		$___path = "${___path}.exe"
+		if ($(FS-Is-File "${___path}") -ne 0) {
+			$___path = "C:\Program Files\LibreOffice\program\soffice.exe"
+		}
 	} default {
-		$___path = "${env:PROJECT_PATH_ROOT}\${env:PROJECT_PATH_TOOLS}\libreoffice\bin\libreoffice"
+		$___path = "/bin/soffice"
 	}}
 
 
@@ -68,8 +95,6 @@ function LIBREOFFICE-Get-Path {
 
 function LIBREOFFICE-Is-Available {
 	# execute
-	$null = OS-Sync
-
 	$___process = OS-Is-Command-Available "libreoffice"
 	if ($___process -eq 0) {
 		return 0
@@ -110,87 +135,67 @@ function LIBREOFFICE-Setup {
 
 
 	# execute
-	if ($(OS-Get) -eq "darwin") {
-		$___dest = "${env:PROJECT_PATH_ROOT}\${env:PROJECT_PATH_TEMP}\libreoffice\instal.dmg"
-		$null = FS-Make-Housing-Directory "${___dest}"
-		$null = FS-Remove-Silently "${___dest}"
+	$___dest = "${env:PROJECT_PATH_ROOT}\${env:PROJECT_PATH_TOOLS}\${env:PROJECT_PATH_LIBREOFFICE_ENGINE}"
+	$___url = "${env:PROJECT_LIBREOFFICE_MIRROR}/stable/${env:PROJECT_LIBREOFFICE_VERSION}"
+	switch ("${env:PROJECT_OS}") {
+	"darwin" {
+		$___dest = "${___dest}\install.dmg"
 
-
-		## Download directly from provider
-		$___url = "${env:PROJECT_LIBREOFFICE_MIRROR}/stable/${env:PROJECT_LIBREOFFICE_VERSION}"
 		$___url = "${___url}/mac"
-		if ($(OS-Get-Arch) -eq "amd64") {
+		switch ("${env:PROJECT_ARCH}") {
+		"amd64" {
 			$___url = "${___url}/x86_64"
 			$___url = "${___url}/LibreOffice_${env:PROJECT_LIBREOFFICE_VERSION}_MacOS_x86-64.dmg"
-		} elseif ($(OS-Get-Arch) -eq "arm64") {
+		} "arm64" {
 			$___url = "${___url}/aarch64"
 			$___url = "${___url}/LibreOffice_${env:PROJECT_LIBREOFFICE_VERSION}_MacOS_aarch64.dmg"
-		} else {
-			return 1
+		} default {
+			$___url = ""
+		}}
+
+		## attempt to download from vendor directly
+		if ($(STRINGS-Is-Empty "${___url}") -ne 0) {
+			$null = FS-Make-Housing-Directory "${___dest}"
+			$null = FS-Remove-Silently "${___dest}"
+			$___process = HTTP-Download "GET" "${___url}" "${___dest}"
+			if ($___process -ne 0) {
+				return 1
+			}
+
+			$___process = Apple-Install-DMG "${___dest}"
+			if ($___process -ne 0) {
+				return 1
+			}
+
+			$null = FS-Remove-Silently "${___dest}"
 		}
+	} "windows" {
+		$___dest = "${___dest}\install.msi"
 
-
-		# download from provider
-		$___process = HTTP-Download "GET" "${___url}" "${___dest}"
-		if ($___process -ne 0) {
-			return 1
-		}
-
-
-		## silently install
-		$___process = Apple-Install-DMG "${___dest}"
-		if ($___process -ne 0) {
-			return 1
-		}
-
-
-		## clean up
-		$null = FS-Remove-Silently "${___dest}"
-	} elseif ($(OS-Get) -eq "windows") {
-		## Attempt to use directly from the provider
-		$___dest = "${env:PROJECT_PATH_ROOT}\${env:PROJECT_PATH_TEMP}\libreoffice\install.msi"
-		$null = FS-Make-Housing-Directory "${___dest}"
-		$null = FS-Remove-Silently "${___dest}"
-
-
-		$___url = "${env:PROJECT_LIBREOFFICE_MIRROR}/stable/${env:PROJECT_LIBREOFFICE_VERSION}"
 		$___url = "${___url}/win"
-		if ($(OS-Get-Arch) -eq "amd64") {
+		switch ("${env:PROJECT_ARCH}") {
+		"amd64" {
 			$___url = "${___url}/x86_64"
 			$___url = "${___url}/LibreOffice_${env:PROJECT_LIBREOFFICE_VERSION}_Win_x86-64.msi"
-		} elseif ($(OS-Get-Arch) -eq "arm64") {
+		} "arm64" {
 			$___url = "${___url}/aarch64"
 			$___url = "${___url}/LibreOffice_${env:PROJECT_LIBREOFFICE_VERSION}_Win_aarch64.msi"
-		} else {
-			## fallback to choco as the last resort
-			$___process = OS-Is-Command-Available "choco"
-			if ($___process -ne 0) {
-				return 1
+		} default {
+			$___url = ""
+		}}
+
+		if ($(STRINGS-Is-Empty "${___url}") -ne 0) {
+			$null = FS-Make-Housing-Directory "${___dest}"
+			$null = FS-Remove-Silently "${___dest}"
+			$___process = HTTP-Download "GET" "${___url}" "${___dest}"
+			if ($___process -eq 0) {
+				$___process = MSI-Install-Silent "${___dest}"
+				$null = FS-Remove-Silently "${___dest}"
 			}
-
-			$___process = OS-Exec "choco" "install libreoffice-fresh -y"
-			if ($___process -ne 0) {
-				return 1
-			}
-
-			return 0
 		}
 
-		$___process = HTTP-Download "GET" "${___url}" "${___dest}"
-		if ($___process -ne 0) {
-			return 1
-		}
-
-		$___process = FS-Is-File "${___dest}"
-		if ($___process -ne 0) {
-			return 1
-		}
-
-		$___process = MSI-Install-Silent "${___dest}"
-		$null = FS-Remove-Silently "${___dest}"
-		$null = OS-Sync
-		if ($___process -ne 0) {
-			## fallback to choco as the last resort
+		## fallback to choco as the last resort
+		if (($(STRINGS-Is-Empty "${___url}") -eq 0) -or ($___process -ne 0)) {
 			$___process = OS-Is-Command-Available "choco"
 			if ($___process -ne 0) {
 				return 1
@@ -202,27 +207,47 @@ function LIBREOFFICE-Setup {
 			}
 
 			$null = OS-Sync
-			return 0
 		}
-	} else {
-		## check compatible platform version
-		$___url = "https://appimages.libreitalia.org"
-		switch ("$(OS-Get-Arch)") {
-		"amd64" {
-			$___url = "${___url}/LibreOffice-fresh.full-x86_64.AppImage"
-		} default {
-			return 1
-		}}
+	} "linux" {
+		$___process = OS-Is-Command-Available "flatpak"
+		if ($___process -eq 0) {
+			$___process = OS-Exec "flatpak" "--user install org.libreoffice.LibreOffice"
+		}
 
-
-		## download appimage portable version
-		$___dest = "${env:PROJECT_PATH_ROOT}\${env:PROJECT_PATH_TOOLS}\libreoffice\bin\libreoffice"
-		$null = FS-Make-Housing-Directory "${___dest}"
-		$null = FS-Remove-Silently "${___dest}"
-		$___process = HTTP-Download "GET" "${___url}" "${___dest}"
+		## download appimage as last resort
 		if ($___process -ne 0) {
-			return 1
+			$___dest = LIBREOFFICE-Get-Path-Local
+			$___url = "https://appimages.libreitalia.org"
+			switch ("${env:PROJECT_ARCH}") {
+			"amd64" {
+				$___url = "${___url}/LibreOffice-fresh.full-x86_64.AppImage"
+			} default {
+				return 1
+			}}
+
+			if ($(STRINGS-Is-Empty "${___url}") -ne 0) {
+				$null = FS-Make-Housing-Directory "${___dest}"
+				$null = FS-Remove-Silently "${___dest}"
+				$___process = HTTP-Download "GET" "${___url}" "${___dest}"
+				if ($___process -ne 0) {
+					return 1
+				}
+
+				$___process = FS-Is-File "${___dest}"
+				if ($___process -ne 0) {
+					return 1
+				}
+			}
 		}
+	} default {
+		return 1 # unsupported
+	}}
+
+
+	# test the output
+	$___process = LIBREOFFICE-Is-Available
+	if ($___process -ne 0) {
+		return 1
 	}
 
 

--- a/srcRESEARCH/.ci/build_unix-any.sh
+++ b/srcRESEARCH/.ci/build_unix-any.sh
@@ -1,0 +1,106 @@
+#!/bin/sh
+# Copyright 2024 (Holloway) Chew, Kean Ho <hello@hollowaykeanho.com>
+#
+# Licensed under the Apache License, Version 2.0 (the "License"); you may not
+# use this file except in compliance with the License. You may obtain a copy of
+# the License at:
+#                 http://www.apache.org/licenses/LICENSE-2.0
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+# WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+# License for the specific language governing permissions and limitations under
+# the License.
+
+
+
+
+# initialize
+if [ "$PROJECT_PATH_ROOT" = "" ]; then
+        >&2 printf "[ ERROR ] - Please run from automataCI/ci.sh.ps1 instead!\n"
+        return 1
+fi
+
+. "${LIBS_AUTOMATACI}/services/io/fs.sh"
+. "${LIBS_AUTOMATACI}/services/i18n/translations.sh"
+. "${LIBS_AUTOMATACI}/services/compilers/libreoffice.sh"
+
+
+
+
+# execute
+I18N_Activate_Environment
+LIBREOFFICE_Is_Available
+if [ $? -ne 0 ]; then
+        I18N_Activate_Failed
+        return 1
+fi
+
+
+
+
+# setup inportant variables
+___name="${PROJECT_SKU}-${PROJECT_RESEARCH_IDENTIFIER}_${PROJECT_VERSION}_any-any"
+___source="research-paper.odt"
+
+
+
+
+# build PDF
+___source="${PROJECT_PATH_ROOT}/${PROJECT_RESEARCH}/${___source}"
+___dest="${PROJECT_PATH_ROOT}/${PROJECT_PATH_TEMP}/build-${___name}"
+I18N_Prepare "$___source"
+FS_Is_File "$___source"
+if [ $? -ne 0 ]; then
+        I18N_Prepare_Failed
+        return 1
+fi
+
+FS_Remake_Directory "$___dest"
+
+## IMPORTANT: refer the following page for modifying parameters:
+##   https://help.libreoffice.org/latest/en-US/text/shared/guide/pdf_params.html
+I18N_Build "$___source"
+$(LIBREOFFICE_Get) --headless --convert-to "pdf:writer_pdf_Export:{
+        \"UseLosslessCompression\": true,
+        \"Quality\": 100,
+        \"SelectPdfVersion\": 0,
+        \"PDFUACompliance\": false,
+        \"UseTaggedPDF\": true,
+        \"ExportFormFields\": true,
+        \"FormsType\": 1,
+        \"ExportBookmarks\": true,
+        \"ExportPlaceholders\": true
+}" --outdir "$___dest" "$___source"
+___process=$?
+if [ $___process -ne 0 ]; then
+        I18N_Build_Failed
+        return 1
+fi
+
+
+
+
+## export output
+___source="${___dest}/$(FS_Get_File "$___source")"
+___source="$(FS_Extension_Replace "$___source" ".odt" ".pdf")"
+___dest="${PROJECT_PATH_ROOT}/${PROJECT_PATH_BUILD}/${___name}.pdf"
+
+FS_Is_File "$___source"
+if [ $? -ne 0 ]; then
+        I18N_Build_Failed
+        return 1
+fi
+
+I18N_Export "$___dest"
+FS_Remove_Silently "$___dest"
+FS_Copy_File "$___source" "$___dest"
+if [ $? -ne 0 ]; then
+        I18N_Export_Failed
+        return 1
+fi
+
+
+
+
+# report status
+return 0

--- a/srcRESEARCH/.ci/build_windows-any.ps1
+++ b/srcRESEARCH/.ci/build_windows-any.ps1
@@ -1,0 +1,105 @@
+# Copyright 2024 (Holloway) Chew, Kean Ho <hello@hollowaykeanho.com>
+#
+# Licensed under the Apache License, Version 2.0 (the "License"); you may not
+# use this file except in compliance with the License. You may obtain a copy
+# of the License at:
+#                 http://www.apache.org/licenses/LICENSE-2.0
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+# WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+# License for the specific language governing permissions and limitations
+# under the License.
+
+
+
+
+# initialize
+if (-not (Test-Path -Path $env:PROJECT_PATH_ROOT)) {
+	Write-Error "[ ERROR ] - Please run from automataCI\ci.sh.ps1 instead!`n"
+	return 1
+}
+
+. "${env:LIBS_AUTOMATACI}\services\io\fs.ps1"
+. "${env:LIBS_AUTOMATACI}\services\i18n\translations.ps1"
+. "${env:LIBS_AUTOMATACI}\services\compilers\libreoffice.ps1"
+
+
+
+
+# execute
+$null = I18N-Activate-Environment
+$___process = LIBREOFFICE-Is-Available
+if ($___process -ne 0) {
+	$null = I18N-Activate-Failed
+	return 1
+}
+
+
+
+
+# setup important variables
+$___name = "${env:PROJECT_SKU}-${env:PROJECT_RESEARCH_IDENTIFIER}_${env:PROJECT_VERSION}_any-any"
+$___source = "research-paper.odt"
+
+
+
+
+# build PDF
+$___source = "${env:PROJECT_PATH_ROOT}\${env:PROJECT_RESEARCH}\${___source}"
+$___dest = "${env:PROJECT_PATH_ROOT}\${env:PROJECT_PATH_TEMP}\build-${___name}"
+$null = I18N-Prepare "${___source}"
+$___process = FS-Is-File "${___source}"
+if ($___process -ne 0) {
+	$null = I18N-Prepare-Failed
+	return 1
+}
+$null = FS-Remake-Directory "${___dest}"
+
+## IMPORTANT: refer the following page for modifying parameters:
+##   https://help.libreoffice.org/latest/en-US/text/shared/guide/pdf_params.html
+$null = I18N-Build "${___source}"
+$___process = OS-Exec "$(LIBREOFFICE-Get)" @"
+--headless --convert-to "pdf:writer_pdf_Export:{
+	"UseLosslessCompression": true,
+	"Quality": 100,
+	"SelectPdfVersion": 0,
+	"PDFUACompliance": false,
+	"UseTaggedPDF": true,
+	"ExportFormFields": true,
+	"FormsType": 1,
+	"ExportBookmarks": true,
+	"ExportPlaceholders": true,
+}" --outdir "${___dest}" "${___source}"
+"@
+if ($___process -ne 0) {
+	$null = I18N-Build-Failed
+	return 1
+}
+
+
+
+
+# export output
+$___source = "${___dest}\$(FS-Get-File "${___source}")"
+$___source = FS-Extension-Replace "${___source}" ".odt" ".pdf"
+$___dest = "${env:PROJECT_PATH_ROOT}\${env:PROJECT_PATH_BUILD}\${___name}.pdf"
+
+$___process = FS-Is-File "${___source}"
+if ($___process -ne 0) {
+	$null = I18N-Build-Failed
+	return 1
+}
+
+$null = I18N-Export "${___dest}"
+$null = FS-Remove-Silently "${___dest}"
+$___process = FS-Copy-File "${___source}" "${___dest}"
+if ($___process -ne 0) {
+	$null = I18N-Export-Failed
+	return 1
+}
+
+
+
+
+# report status
+return 0


### PR DESCRIPTION
Since we want this library to be reliably good, we should enable the research paper pipeline and place all our details and data in it. That way, interested folks and code auditors can review the materials without needing to ping-pong with the maintainers that often.

This patch enables research paper pipeline (srcRESEARCH) in root repository.